### PR TITLE
Allow larger LUT table for additional power levels

### DIFF
--- a/libloragw/inc/loragw/loragw_hal.h
+++ b/libloragw/inc/loragw/loragw_hal.h
@@ -150,7 +150,7 @@ Maintainer: Sylvain Miermont
 #define RX_SUSPENDED        3    /* RX is suspended while a TX is ongoing */
 
 /* Maximum size of Tx gain LUT */
-#define TX_GAIN_LUT_SIZE_MAX 16
+#define TX_GAIN_LUT_SIZE_MAX 32
 
 /* LBT constants */
 #define LBT_CHANNEL_FREQ_NB 8 /* Number of LBT channels */


### PR DESCRIPTION
Allow a larger LUT table so that additional power levels can be configured. The current limitation of 16 power levels often leads to the use of wrong tx power because the LUT table is missing entries.